### PR TITLE
Scheduling and Mode Detection Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6]
+
+### Added
+
+- Scheduled Run Time from Shark App (Preference) - Use this setting with Smart State Refresh Enabled to allow refreshes to lie dormant.  This setting should be set to the same time the Shark is scheduled to run through the Shark App.  If disabled, dormant refreshes default to 15 minutes. 
+- Schedule_Type (Attribute) - This Attribute shows the current type of refresh schedule your Shark device is following.
+
+### Changed
+
+- State Detection Improvements - Fixed a bug where if Recharging to Resume was null, the robot would always show Returning to Dock.
+- Scheduling done by cron instead of RunIn - since cron scheduling survives a hub reboot, it is a more hands-off way of managing scheduling for your robot vacuum.  Once set, the schedule will faithfully run allowing any rules set up to auto run without intervention.
+
 ## [1.0.5]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Please send feedback and/or issues to the Hubitat Forum Thread: https://communit
 | Smart State Refresh | If enabled, will only refresh when vacuum is running (per interval), then every 5 minutes until Fully Charged. Takes precedence over Scheduled State Refresh. |
 | Google Home Compatibility | Toggle to add a 'status' state |
 | Enable Debug Logging | Adds more logging information. |
+| Scheduled Run Time from Shark App | Enter the time Shark is scheduled to run through the Shark App to control dormant smart scheduling, blank to disable and default to 15 minute pings when dormant |
 
 <br>
 
@@ -112,6 +113,15 @@ You can also pull current states to a dashboard tile as well. To do so:
 3. Choose the template "Attribute".
 4. Select the attribute from the dropdown.
 
+### Schedule Types
+| Schedule Type  | Description |
+| ------------- | ------------- |
+| Smart Refresh - Active | The Shark is actively cleaning, paused, or docking. Refreshes will occur every minute by default or as set in Refresh Interval parameter. |
+| Smart Refresh - Charging | The Shark is charging on the dock. Refreshes will occur every 5 minutes until fully charged. |
+| Smart Scheduled Refresh - Dormant | The Shark is fully charged resting on the dock. Refreshes have been scheduled according to the time supplied in Scheduled Run Time from Shark App parameter. |
+| Smart Interval Refresh - Dormant | The Shark is fully charged resting on the dock. Refreshes have been scheduled every 15 minutes. |
+| Unscheduled | No schedule has been set for refreshing the status of your Shark. Modify your preferences to enable scheduled refreshes. |
+| Scheduled Refresh | The Shark's status will be refreshed on a recurring interval as set in the Refresh Interval parameter. |
 
 # Donations
 To support this project, you can make a donation to its current maintainer:

--- a/SharkIQRobotDriver.groovy
+++ b/SharkIQRobotDriver.groovy
@@ -19,7 +19,8 @@
  *
  */
 
-import groovy.json.*
+import java.String.*
+import groovy.time.*
 import java.util.regex.*
 import java.text.SimpleDateFormat
 
@@ -43,6 +44,7 @@ metadata {
         attribute "Firmware_Version","text"
         attribute "Last_Refreshed","text"
         attribute "Recharging_To_Resume","text"
+        attribute "Schedule_Type","text"
     }
  
     preferences {
@@ -51,10 +53,11 @@ metadata {
         input(name: "sharkDeviceName", type: "string", title: "Device Name", description: "Name you've given your Shark Device within the App", required: true, displayDuringSetup: true)
         input(name: "mobileType", type: "enum", title: "Mobile Device", description: "Type of Mobile Device your Shark is setup on", required: true, displayDuringSetup: true, options:["Apple iOS", "Android OS"])
         input(name: "refreshEnable", type: "bool", title: "Scheduled State Refresh", description: "If enabled, after you click 'Save Preferences', click the 'Refresh' button to start the schedule.", defaultValue: false)
-        input(name: "refreshInterval", type: "integer", title: "Refresh Interval", description: "Number of seconds between State Refreshes", required: true, displayDuringSetup: true, defaultValue: 60)
-        input(name: "smartRefresh", type: "bool", title: "Smart State Refresh", description: "If enabled, will only refresh when vacuum is running (per interval), then every 5 minutes until Fully Charged. Takes precedence over Scheduled State Refresh.", required: true, displayDuringSetup: true, defaultValue: true)
+        input(name: "refreshInterval", type: "integer", title: "Refresh Interval", description: "Number of minutes between Scheduled State Refreshes. Active only if Scheduled State Refresh is turned on", required: true, displayDuringSetup: true, defaultValue: 1)
+        input(name: "smartRefresh", type: "bool", title: "Smart State Refresh", description: "If enabled, will only refresh when vacuum is running (per interval), then every 5 minutes until Fully Charged. After running, polls less frequently or as scheduled through the Shark App. Takes precedence over Scheduled State Refresh.", required: true, displayDuringSetup: true, defaultValue: true)
         input(name: "debugEnable", type: "bool", title: "Enable Debug Logging", defaultValue: true)
         input(name: "googleHomeCompat", type: "bool", title: "Google Home Compatibility", description: "If enabled, Operating Mode will either be 'docked' or 'undocked'.", defaultValue: false)
+        input(name: "scheduledTime", type: "time", title: "Scheduled Run Time from Shark App", description: "Enter the time Shark is scheduled to run through the Shark App, blank to disable", required: false, displayDuringSetup: true, defaultValue: null)
     }
 }
 
@@ -65,31 +68,73 @@ def refresh() {
     {
         if (operatingMode in ["Paused", "Running", "Returning to Dock", "Recharging to Continue"])
         {
-            logging("d", "Refresh scheduled in $refreshInterval seconds.")
-            runIn("$refreshInterval".toInteger(), refresh)
+            if(device.currentValue('Schedule_Type') != "Smart Refresh - Active")
+            {
+                logging("d", "Refresh scheduled in $refreshInterval minutes.")
+                schedule("0 */$refreshInterval * * * ? *", refresh)
+            }
+            eventSender("Schedule_Type", "Smart Refresh - Active", true)
         }
-        else if (operatingMode in ["Charging on Dock"] && batteryCapacity.toString() != "100")
+        else if (operatingMode in ["Charging on Dock"])
         {
-            logging("d", "Refresh scheduled in 300 seconds.")
-            runIn(300, refresh)
+            if(device.currentValue('Schedule_Type') != "Smart Refresh - Charging")
+            {
+                logging("d", "Refresh scheduled in 5 minutes.")
+                schedule("0 */5 * * * ? *", refresh)
+            }  
+            eventSender("Schedule_Type", "Smart Refresh - Charging", true)
+        }        
+        else if (operatingMode in ["Resting on Dock"])
+        {
+			if (scheduledTime != null)
+			{
+				String hour = scheduledTime.substring(11,13)
+				String minute = scheduledTime.substring(14,16)
+				if(device.currentValue('Schedule_Type') != "Smart Scheduled Refresh - Dormant")
+				{
+					logging("d", "Refresh scheduled for $hour:$minute.")
+					schedule("*/30 $minute $hour * * ? *", refresh)
+					eventSender("Schedule_Type", "Smart Scheduled Refresh - Dormant", true)
+
+				}
+			} 
+			else
+			{
+				if(device.currentValue('Schedule_Type') != "Smart Interval Refresh - Dormant")
+				{
+					logging("d", "Refresh scheduled in 15 minutes.")
+					schedule("0 */15 * * * ? *", refresh)
+					eventSender("Schedule_Type", "Smart Interval Refresh - Dormant", true)
+				}
+			}
         }
         else
         {
             logging("d", "Not scheduling a refresh, because the operatingMode = $operatingMode")
+            unschedule()
+            eventSender("Schedule_Type", "Unscheduled", true)
         }
     }
     else if (!smartRefresh && refreshEnable)
     {
-        logging("d", "Refresh scheduled in $refreshInterval seconds.")
-        runIn("$refreshInterval".toInteger(), refresh)
+        if (device.currentValue('Schedule_Type') != "Scheduled Refresh")
+        {
+            logging("d", "Refresh scheduled in $refreshInterval minutes.")
+            schedule("0 */$refreshInterval * * * ? *", refresh)
+        }
+        eventSender("Schedule_Type", "Scheduled Refresh", true)
     }
     else if (smartRefresh && refreshEnable)
     {
         logging("e", "Not scheduling refresh - Please enable only 1 refresh type (Smart or Scheduled).")
+        unschedule()
+        eventSender("Schedule_Type", "Unscheduled", true)
     }
     else
     {
         logging("d", "No options chosen for scheduled refresh.")
+        unschedule()
+        eventSender("Schedule_Type", "Unscheduled", true)
     }
 
 }
@@ -141,7 +186,7 @@ def locate() {
     runIn(10, refresh)
 }
 
-def getRobotInfo(){
+def getRobotInfo() {
     propertiesResults = runGetPropertiesCmd("names[]=GET_Main_PCB_BL_Version&names[]=GET_Main_PCB_HW_Version&names[]=GET_Main_PCB_FW_Version&names[]=GET_Nav_Module_FW_Version&names[]=GET_Nav_Module_App_Version&names[]=GET_SCM_FW_Version")
     propertiesResults.each { singleProperty ->
         if (singleProperty.property.name == "GET_Main_PCB_BL_Version")
@@ -219,10 +264,12 @@ def grabSharkInfo() {
     // Charging Status
     // chargingStatusValue - 0 = NOT CHARGING, 1 = CHARGING
     charging_status = ["Not Charging", "Charging"]
-    if (device.currentValue('Battery_Level') == "100") {
+    if (device.currentValue('Battery_Level') == "100")
+    {
         chargingStatusToSend = "Fully Charged" 
     }
-    else {
+    else
+    {
         chargingStatusToSend = charging_status[chargingStatusValue]
     }
     eventSender("Charging_Status", chargingStatusToSend, true)
@@ -230,14 +277,18 @@ def grabSharkInfo() {
     // Operating Mode 
     // operatingModeValue - 0 = STOPPED, 1 = PAUSED, 2 = ON, 3 = OFF
     operating_modes = ["Stopped", "Paused", "Running", "Returning to Dock"]
-    if (device.currentValue('Recharging_To_Resume') == "True" && operatingModeValue.toString() == "3") { 
+    if (device.currentValue('Recharging_To_Resume') == "True" && operatingModeValue.toString() == "3")
+    { 
         operatingModeToSend = "Recharging to Continue" 
     }
-    else if (device.currentValue('Recharging_To_Resume') == "False" && operatingModeValue.toString() == "3") {
-        if (device.currentValue('Charging_Status') == "Fully Charged") {
+    else if (device.currentValue('Recharging_To_Resume') != "True" && operatingModeValue.toString() == "3")
+    {
+        if (device.currentValue('Charging_Status') == "Fully Charged")
+        {
             operatingModeToSend = "Resting on Dock" 
         }
-        else if (device.currentValue('Charging_Status') == "Charging"){
+        else if (device.currentValue('Charging_Status') == "Charging")
+        {
             operatingModeToSend = "Charging on Dock" 
         }
         else {
@@ -293,11 +344,13 @@ def runGetPropertiesCmd(String operation) {
 private performHttpPost(params) {
     try {
         httpPost(params) { response ->
-            if(response.getStatus() == 200 || response.getStatus() == 201) {
+            if(response.getStatus() == 200 || response.getStatus() == 201)
+            {
                 results = response.data
                 logging("d", "Response received from Shark in the postResponseHandler. $response.data")
             }
-            else {
+            else
+            {
                 logging("e", "Shark failed. Shark returned ${response.getStatus()}.")
                 logging("e", "Error = ${response.getErrorData()}")
             }
@@ -312,11 +365,13 @@ private performHttpPost(params) {
 private performHttpGet(params) {
     try {
         httpGet(params) { response ->
-            if(response.getStatus() == 200 || response.getStatus() == 201) {
+            if(response.getStatus() == 200 || response.getStatus() == 201)
+            {
                 results = response.data
                 logging("d", "Response received from Shark in the getResponseHandler. $response.data")
             }
-            else {
+            else
+            {
                 logging("e", "Shark failed. Shark returned ${response.getStatus()}.")
                 logging("e", "Error = ${response.getErrorData()}")
             }
@@ -332,11 +387,13 @@ def login() {
     def localDevicePort = (devicePort==null) ? "80" : devicePort
     def app_id = ""
     def app_secret = ""
-    if (mobileType == "Apple iOS") {
+    if (mobileType == "Apple iOS")
+    {
         app_id = "Shark-iOS-field-id"
         app_secret = "Shark-iOS-field-_wW7SiwgrHN8dpU_ugCattOoDk8"
     }
-    else if (mobileType == "Android OS") {
+    else if (mobileType == "Android OS")
+    {
         app_id = "Shark-Android-field-id"
         app_secret = "Shark-Android-field-Wv43MbdXRM297HUHotqe6lU1n-w"
     }
@@ -352,13 +409,15 @@ def login() {
     ]
     try {
         httpPost(params) { response ->
-            if(response.getStatus() == 200 || response.getStatus() == 201) {
+            if(response.getStatus() == 200 || response.getStatus() == 201)
+            {
                 logging("d","Response received from Shark in the postResponseHandler. $response.data")
                 def accesstokenstring = ("$response.data" =~ /access_token:([A-Za-z0-9]*.*?)/)
                 authtoken = accesstokenstring[0][1]
                 return response
             }
-            else {
+            else
+            {
                 logging("e","Shark failed. Shark returned ${response.getStatus()}.")
                 logging("e","Error = ${response.getErrorData()}")
             }
@@ -376,13 +435,15 @@ def getUserProfile() {
     ]
     try {
         httpGet(params) { response ->
-            if(response.getStatus() == 200 || response.getStatus() == 201) {
+            if(response.getStatus() == 200 || response.getStatus() == 201)
+            {
                 logging("d","Response received from Shark in the postResponseHandler. $response.data")
                 def uuidstring = ("$response.data" =~ /uuid:([A-Za-z0-9-]*.*?)/)
                 uuid = uuidstring[0][1]
                 return response
             }
-            else {
+            else
+            {
                 logging("e", "Shark failed. Shark returned ${response.getStatus()}.")
                 logging("e", "Error = ${response.getErrorData()}")
             }
@@ -401,10 +462,12 @@ def getDevices() {
     ]
     try {
         httpGet(params) { response ->
-            if(response.getStatus() == 200 || response.getStatus() == 201) {
+            if(response.getStatus() == 200 || response.getStatus() == 201)
+            {
                 logging("d", "Response received from Shark in the postResponseHandler. $response.data")
                 def devicedsn = ""
-                for (devices in response.data.device ) {
+                for (devices in response.data.device )
+                {
                     if ("$sharkDeviceName" == "${devices.product_name}")
                     {   
                         dsnForDevice = "${devices.dsn}"
@@ -416,7 +479,8 @@ def getDevices() {
                 }
                 return response
             }
-            else {
+            else
+            {
                 logging("e", "Shark failed. Shark returned ${response.getStatus()}.")
                 logging("e", "Error = ${response.getErrorData()}")
             }


### PR DESCRIPTION
- Add 'null' as a possible value of Recharging_To_Resume to fix state detection regarding docking
- Change from volatile RunIn() to cron scheduling
- Add property for entering scheduled Shark App runtime for more accurate dormant mode detection
- Add attribute to display what scheduling mode the device is operating on
- standardized formatting

There were some issues I noticed while using this device driver for my Shark IQ 1001.  The biggest issue was that my Recharging_To_Resume property is null every time (I have the setting turned off).  Because of this, the robot was always showing returning to dock instead of resting or charging on the dock.  I changed the logic to say when it is not true instead of explicitly saying False so null could be picked up.

The next issue I ran into was with refreshes.  The refreshes would interrupt if an update or restart was performed causing manual intervention. I went ahead and converted (as close as i could) the scheduling to cron to avoid this issue.  From there, I branched out and added a visible Scheduling Type so the user can get insight into what the device driver is thinking with regards to scheduling.

I added a new property to set the time you've scheduled your robot in the Shark App. This allows smart scheduling to go dormant until the scheduled time, where it will fire up to twice trying to pick up an active robot. There may be some additional improvements we can do here around changing scheduling to a fallback if it doesn't pick up the schedule. 

I hope you can see the value in some of these improvements and merge them. Let me know if i can help clarify or modify anything to make this acceptable.

Thanks!
Rob